### PR TITLE
Strategist docs

### DIFF
--- a/protocol/steward.md
+++ b/protocol/steward.md
@@ -8,11 +8,7 @@ Documentation for the current version of steward can be found here:
 
 ### Deployment
 
-Unlike most chains, Sommelier requires a server API sidecar process (Steward) to be accessible from the internet. Communications to Steward are protected using mutually-authenticated TLS. During our bootstrapping phase, Steward has a harcoded certificate authority to allow Seven Seas client certificates, though the protocol will be expanded to allow new strategist integrators via governance in the v7 upgrade, which will also include an authorization layer mapping specific strategist integrators with the cellar addresses for which they have been approved. For validators, they must create their own self-signed CA and server certificates by following the instructions in the "steward-registry" repo and adding their data via pull request:
-
-[https://github.com/PeggyJV/steward-registry](https://github.com/PeggyJV/steward-registry)
-
-The v7 upgrade will also provide a method for handling this on-chain and will remove the necessity of the registry.
+Unlike most chains, Sommelier requires a server API sidecar process (Steward) to be accessible from the internet. Communications to Steward are protected using mutually-authenticated TLS. Strategists must be approved by governance by submitting a proposal to become a Publisher on chain. The Publisher entry contains their certificate authority and their client endpoint. For validators, they must create their own self-signed CA and server certificates and submit them to the chain as a Subscriber in the x/pubsub module.
 
 The Steward server process must be on a publicly available port, the default of which is 5734, but can be changed as necessary. The fully qualified URL and port number to access your steward instance should be included in your steward-registry pull request.
 
@@ -24,6 +20,4 @@ Steward's API is a GRPC interface which exposes a defined subset of contract fun
 
 Strategists must submit calls to each validator's Steward instance using the defined GRPC API. In order for a call to be made to an Ethereum cellar, these updates must be sent to the Steward instance's of a consensus power of validators. The current architecture defines a periodic voting window every 10 blocks, and the strategist should submit their calls at the beginning of this window to allow for some latency. A call that reverts will remain in the gravity module until it times out, and depending on the revert being either transient or permanent, it may be retried at any time until it times out. The current timeout period is expected to be roughly 12 hours. The v7 upgrade will modify some of these requirements, and rather than timing submissions during voting windows, calls will execute at a height specified by the strategist.
 
-The list of Steward endpoints for each validator can be found in the steward-registry:
-
-[https://github.com/PeggyJV/steward-registry](https://github.com/PeggyJV/steward-registry)
+Available Steward endpoints can be queried from the x/pubsub module on chain. A Subscriber represents a validator's Steward instance, and contains the info necessary for a strategist client to make an authenticated connection.

--- a/strategists/adaptor_reference.md
+++ b/strategists/adaptor_reference.md
@@ -1,0 +1,1 @@
+Under construction

--- a/strategists/adaptor_reference.md
+++ b/strategists/adaptor_reference.md
@@ -87,7 +87,7 @@ message AdaptorCall {
 
 Notice that each available call data type has a plural name, for example `StakingAdaptorV1Calls`. These types are wrappers for their actual respective call types, in this case `StakingAdaptorV1Call` (no 's' at the end) that allow multiple function calls to the same adaptor to be executed in one transaction.  
 
-Each protocol has it's own .proto file where types are defined for adaptor-specific functions. In general, only the latest version of an adaptor proto should be used. That is, if there is a file containing both MyAdaptorV1 and MyAdaptorV2 types, V1 is probably only relevant for older Cellars.
+Each protocol has its own .proto file where types are defined for adaptor-specific functions. In general, only the latest version of an adaptor proto should be used. That is, if there is a file containing both MyAdaptorV1 and MyAdaptorV2 types, V1 is probably only relevant for older Cellars.
 
 The full list of .proto files defining functions for each adaptor can be found [here](https://github.com/PeggyJV/steward/tree/main/proto/steward/v4)
 

--- a/strategists/adaptor_reference.md
+++ b/strategists/adaptor_reference.md
@@ -1,1 +1,93 @@
-Under construction
+# Adaptor Reference
+
+The `CallOnAdaptor` Cellar function allows the strategist the leverage any adaptor contract that is approved by governance and not blocked by Steward. Adaptors are contracts that provide interfaces to other smart contracts such as utility contracts or DeFi protocols such as Aave, Uniswap, Balancer, etc.
+
+All adaptor calls are wrapped in the `AdaptorCall` type, which contains the address of the target adaptor, and the actual adaptor call data. The source code can be found [here](https://github.com/PeggyJV/steward/blob/fe82aa23542bdf6c28233b59ba507b9beb52014a/proto/steward/v4/cellar_v2.proto#L1273-L1350):
+
+```protobuf
+// Represents a call to an adaptor contract. The cellar must be authorized to call the target adaptor.
+message AdaptorCall {
+    // Address of the adaptor
+    string adaptor = 1;
+    // The function call data for the adaptor
+    oneof call_data {
+        // Represents function calls to the AaveATokenAdaptor V1
+        AaveATokenAdaptorV1Calls aave_a_token_v1_calls = 2;
+        // Represents function calls to the AavaDebtTokenAdaptor V1
+        AaveDebtTokenAdaptorV1Calls aave_debt_token_v1_calls = 3;
+        // Represents function calls to the CompoundCTokenAdaptor V2
+        CompoundCTokenAdaptorV2Calls compound_c_token_v2_calls = 4;
+        // Represents function calls to the AaveATokenV2Adaptor
+        AaveATokenAdaptorV2Calls aave_a_token_v2_calls = 5;
+        // Represents function calls to the AavaDebtTokenV2Adaptor
+        AaveDebtTokenAdaptorV2Calls aave_debt_token_v2_calls = 6;
+        // Represents function calls to the AaveATokenV1Adaptor
+        AaveV3ATokenAdaptorV1Calls aave_v3_a_token_v1_calls = 7;
+        // Represents function calls to the AavaDebtTokenV1Adaptor
+        AaveV3DebtTokenAdaptorV1Calls aave_v3_debt_token_v1_calls = 8;
+        // Represents function calls to the OneInchAdaptorV1
+        OneInchAdaptorV1Calls one_inch_v1_calls = 9;
+        // Represents function calls to the FeesAndReservesAdaptorV1
+        FeesAndReservesAdaptorV1Calls fees_and_reserves_v1_calls = 10;
+        // Represents functionc alls to the ZeroXAdaptorV1
+        ZeroXAdaptorV1Calls zero_x_v1_calls = 11;
+        // Represents function calls to the SwapWithUniswapAdaptorV1
+        SwapWithUniswapAdaptorV1Calls swap_with_uniswap_v1_calls = 12;
+        // Represents function calls to VestingSimpleAdaptor
+        VestingSimpleAdaptorV2Calls vesting_simple_v2_calls = 13;
+        // Represents function calls to the CellarAdaptor
+        CellarAdaptorV1Calls cellar_v1_calls = 14;
+        // Represents function calls to the UniswapV3Adaptor V2
+        UniswapV3AdaptorV2Calls uniswap_v3_v2_calls = 15;
+        // Represents function calls to the AaveV2EnableAssetAsCollatorAdaptor V1
+        AaveV2EnableAssetAsCollateralAdaptorV1Calls aave_v2_enable_asset_as_collateral_v1_calls = 16;
+        // Represents function calls to the FTokenAdaptor V1
+        FTokenAdaptorV1Calls f_token_v1_calls = 17;
+        // Represents function calls to the MorphoAaveV2AToken V1
+        MorphoAaveV2ATokenAdaptorV1Calls morpho_aave_v2_a_token_v1_calls = 18;
+        // Represents function calls to the MorphoAaveV2DebtToken V1
+        MorphoAaveV2DebtTokenAdaptorV1Calls morpho_aave_v2_debt_token_v1_calls = 19;
+        // Represents function calls to the MorphoAaveV3ATokenCollateral V1
+        MorphoAaveV3ATokenCollateralAdaptorV1Calls morpho_aave_v3_a_token_collateral_v1_calls = 20;
+        // Represents function calls to the MorphoAaveV3ATokenP2P V1
+        MorphoAaveV3ATokenP2PAdaptorV1Calls morpho_aave_v3_a_token_p2p_v1_calls = 21;
+        // Represents function calls to the MorphoAaveV3DebtToken V1
+        MorphoAaveV3DebtTokenAdaptorV1Calls morpho_aave_v3_debt_token_v1_calls = 22;
+        // Represents function calls to the BalancerPoolAdaptor V1
+        BalancerPoolAdaptorV1Calls balancer_pool_v1_calls = 23;
+        // Represents function calls to the LegacyCellarAdaptor V1
+        LegacyCellarAdaptorV1Calls legacy_cellar_v1_calls = 24;
+        // Represents function calls to the DebtFTokenAdaptor V1
+        DebtFTokenAdaptorV1Calls debt_f_token_v1_calls = 25;
+        // Represents function calls to the CollateralFTokenAdaptor V1
+        CollateralFTokenAdaptorV1Calls collateral_f_token_v1_calls = 26;
+        // Represents function call for the AaveV3DebtTokenAdaptorV1
+        AaveV3DebtTokenAdaptorV1FlashLoanCalls aave_v3_debt_token_v1_flash_loan_calls = 27;
+        // Represents function call for the BalancerPoolAdaptorV1
+        BalancerPoolAdaptorV1FlashLoanCalls balancer_pool_v1_flash_loan_calls = 28;
+        // Represents function calls for the ConvexCurveAdaptorV1
+        ConvexCurveAdaptorV1Calls convex_curve_v1_calls = 29;
+        // Represents function calls for the CurveAdaptorV1
+        CurveAdaptorV1Calls curve_v1_calls = 30;
+        // Represents function calls for the AuraERC4626AdaptorV1
+        AuraERC4626AdaptorV1Calls aura_erc4626_v1_calls = 31;
+        // Represents function calls for the MorphoBlueCollateralAdaptorV1
+        MorphoBlueCollateralAdaptorV1Calls morpho_blue_collateral_v1_calls = 32;
+        // Represents function calls for the MorphoBlueDebtAdaptorV1
+        MorphoBlueDebtAdaptorV1Calls morpho_blue_debt_v1_calls = 33;
+        // Represents function calls for the MorphoBlueSupplyAdaptorV1
+        MorphoBlueSupplyAdaptorV1Calls morpho_blue_supply_v1_calls = 34;
+        // Represents function calls for the ERC4626AdaptorV1 
+        ERC4626AdaptorV1Calls erc4626_v1_calls = 35;
+        // Represents function calls for the StakingAdaptorV1
+        StakingAdaptorV1Calls staking_v1_calls = 36;
+    }
+}
+```
+
+Notice that each available call data type has a plural name, for example `StakingAdaptorV1Calls`. These types are wrappers for their actual respective call types, in this case `StakingAdaptorV1Call` (no 's' at the end) that allow multiple function calls to the same adaptor to be executed in one transaction.  
+
+Each protocol has it's own .proto file where types are defined for adaptor-specific functions. In general, only the latest version of an adaptor proto should be used. That is, if there is a file containing both MyAdaptorV1 and MyAdaptorV2 types, V1 is probably only relevant for older Cellars.
+
+The full list of .proto files defining functions for each adaptor can be found [here](https://github.com/PeggyJV/steward/tree/main/proto/steward/v4)
+

--- a/strategists/adaptor_reference.md
+++ b/strategists/adaptor_reference.md
@@ -1,6 +1,6 @@
 # Adaptor Reference
 
-The `CallOnAdaptor` Cellar function allows the strategist the leverage any adaptor contract that is approved by governance and not blocked by Steward. Adaptors are contracts that provide interfaces to other smart contracts such as utility contracts or DeFi protocols such as Aave, Uniswap, Balancer, etc.
+The `CallOnAdaptor` Cellar function allows the strategist the leverage any adaptor contract that is approved by governance and not blocked by Steward. Adaptors are contracts that provide interfaces to other smart contracts such as utility contracts or DeFi protocols such as Aave, Uniswap, Balancer, etc. The source code for adaptor contracts can be found [in the cellar-contracts repository](https://github.com/PeggyJV/cellar-contracts/tree/main/src/modules/adaptors)
 
 All adaptor calls are wrapped in the `AdaptorCall` type, which contains the address of the target adaptor, and the actual adaptor call data. The source code can be found [here](https://github.com/PeggyJV/steward/blob/fe82aa23542bdf6c28233b59ba507b9beb52014a/proto/steward/v4/cellar_v2.proto#L1273-L1350):
 

--- a/strategists/cellar_functions.md
+++ b/strategists/cellar_functions.md
@@ -1,0 +1,1 @@
+Under construction

--- a/strategists/cellar_functions.md
+++ b/strategists/cellar_functions.md
@@ -48,6 +48,8 @@ Allows strategists to manage their Cellar using arbitrary logic calls to adaptor
 
 Represents function `callOnAdaptor(AdaptorCall[] memory data)`
 
+Adaptor call data make up the majority of the protobuf definitions. As such, they have their own reference documentation [here](./adaptor_reference.md).
+
 #### Fields
 - `data`: (`AdaptorCall[]`) Array of adaptor calls
 

--- a/strategists/cellar_functions.md
+++ b/strategists/cellar_functions.md
@@ -1,1 +1,238 @@
-Under construction
+# Cellar Functions
+
+While there are multiple versions of the Cellar contract architecture, most strategists will only be using Cellar v2.5. Therefore, this document will focus on the Cellar v2.5 functions.
+
+The protobuf definitions can be found [here](). A `CellarV2_5` message is the top level type that is passed in the `call_data` field of a `ScheduleRequest`.
+
+```protobuf
+message CellarV2_5 {
+    oneof call_type {
+        // Represents a single function call
+        FunctionCall function_call = 1;
+        // Represents multiple, ordered function calls
+        Multicall multicall = 2;
+    }
+}
+```
+
+## Fields
+
+There is only one field in the `CellarV2_5` type, `call_type`. It determines the type of function call to execute. As this is a `oneof` field, only one of the following fields can be set:
+
+- `function_call`: A single function call.
+- `multicall`: Multiple function calls that will execute in a single transaction.
+
+## Functions
+
+The actual function types are defined inside of the `CellarV2_5` message and can be seen [here](https://github.com/PeggyJV/steward/blob/fe82aa23542bdf6c28233b59ba507b9beb52014a/proto/steward/v4/cellar_v2.proto#L788-L1012) or read on for the details of each function.
+
+Note, some functions are destined to be gated by governance and are only temporarily availabe while we migrate strategists to the new workflow. These will be marked as such below.
+
+Additionally, the Cellar contract can be found [here](https://github.com/PeggyJV/cellar-contracts/blob/main/src/base/Cellar.sol). Each of the definitions below map to a function of the same name in the solidity code.
+
+Sure! Here is the complete Markdown v2 documentation in one code block:
+
+```markdown
+### AddPosition
+
+Insert a trusted position to the list of positions used by the cellar at a given index.
+
+Represents function `addPosition(uint32 index, uint32 positionId, bytes configurationData, bool inDebtArray)`
+
+#### Fields
+- `index`: (`uint32`) Index at which to add the position
+- `position_id`: (`uint32`) The position's ID in the cellar registry
+- `configuration_data`: (`bytes`) Data used to configure how the position behaves
+- `in_debt_array`: (`bool`) Whether to add position in the debt array, or the credit array
+
+### CallOnAdaptor
+
+Allows strategists to manage their Cellar using arbitrary logic calls to adaptors.
+
+Represents function `callOnAdaptor(AdaptorCall[] memory data)`
+
+#### Fields
+- `data`: (`AdaptorCall[]`) Array of adaptor calls
+
+### RemovePosition
+
+Remove the position at a given index from the list of positions used by the cellar.
+
+Represents function `removePosition(uint32 index, bool inDebtArray)`
+
+#### Fields
+- `index`: (`uint32`) Index at which to remove the position
+- `in_debt_array`: (`bool`) Whether to remove position from the debt array, or the credit array
+
+### SetHoldingPosition
+
+Set the holding position used of the cellar.
+
+Represents function `setHoldingIndex(uint8 index)`
+
+#### Fields
+- `position_id`: (`uint32`) ID (index) of the new holding position to use
+
+### SetStrategistPayoutAddress
+
+Sets the Strategists payout address.
+
+Represents function `setStrategistPayoutAddress(address payout)`
+
+#### Fields
+- `payout`: (`string`) Payout address
+
+### SwapPositions
+
+Swap the positions at two given indeces.
+
+Represents function `swapPositions(uint32 index1, uint32 index2)`
+
+#### Fields
+- `index_1`: (`uint32`) Index of the first position
+- `index_2`: (`uint32`) Index of the second position
+- `in_debt_array`: (`bool`) Whether to switch positions in the debt array, or the credit array
+
+### SetShareLockPeriod
+
+Allows share lock period to be updated.
+
+Represents function `setShareLockPeriod()`
+
+#### Fields
+- `new_lock`: (`string`) New lock period
+
+### InitiateShutdown
+
+Shutdown the cellar. Used in an emergency or if the cellar has been deprecated.
+
+Represents function `initiateShutdown()`
+
+### LiftShutdown
+
+Allows the owner to restart a shut down Cellar
+
+Represents function `liftShutdown()`
+
+### Multicall
+
+Allows caller to call multiple functions in a single TX.
+
+Represents function `multicall(bytes[] data)`
+
+#### Fields
+- `function_calls`: (`FunctionCall[]`) Array of function calls
+
+### RemoveAdaptorFromCatalogue
+
+Allows callers to remove adaptors from this cellar's catalogue
+
+Represents function `removeAdaptorFromCatalogue(address adaptor)`
+
+#### Fields
+- `adaptor`: (`string`) Adaptor address
+
+### RemovePositionFromCatalogue
+
+Allows caller to remove positions from this cellar's catalogue
+
+Represents function `removePositionFromCatalogue(uint32 positionId)`
+
+#### Fields
+- `position_id`: (`uint32`) Position ID
+
+### DecreaseShareSupplyCap
+
+Allows strategist to decrease the share supply cap
+
+Represents function `decreaseShareSupplyCap(uint192)`
+
+#### Fields
+- `new_cap`: (`string`) New share supply cap
+
+### SetAlternativeAssetData
+
+Allows the strategist to add, or update an existing alternative asset deposit.
+
+Represents function `setAlternativeAssetData(ERC20 _alternativeAsset, uint32 _alternativeHoldingPosition, uint32 _alternativeAssetFee)`
+
+#### Fields
+- `alternative_asset`: (`string`) The address of the alternative asset
+- `alternative_holding_position`: (`uint32`) The holding position to direct alternative asset deposits to
+- `alternative_asset_fee`: (`uint32`) The fee to charge for depositing this alternative asset
+
+### DropAlternativeAssetData
+
+Allows the strategist to stop an alternative asset from being deposited.
+
+Represents function `dropAlternativeAssetData(ERC20 _alternativeAsset)`
+
+#### Fields
+- `alternative_asset`: (`string`) The address of the alternative asset
+
+### AddAdaptorToCatalogue
+
+Allows the owner to add an adaptor to the Cellar's adaptor catalogue
+
+Represents function `addAdaptorToCatalogue(address adaptor)`
+
+#### Fields
+- `adaptor`: (`string`) Adaptor address
+
+### AddPositionToCatalogue
+
+Allows the owner to add a position to the Cellar's position catalogue
+
+Represents function `addPositionToCatalogue(uint32 positionId)`
+
+#### Fields
+- `position_id`: (`uint32`) Position ID
+
+### SetRebalanceDeviation
+
+Changes the cellar's allowed rebalance deviation, which is the percent the total assets of a cellar may deviate during a `callOnAdaptor`(rebalance) call. The maximum allowed deviation is 100000000000000000 (0.1e18), or 10%.
+
+Represents function `setRebalanceDeviation(uint256)`
+
+#### Fields
+- `new_deviation`: (`string`) New deviation
+
+### SetStrategistPlatformCut
+
+Allows strategist to set the platform cut for the cellar.
+
+Represents function `setStrategistPlatformCut(uint64 cut)`
+
+#### Fields
+- `new_cut`: (`uint64`) The new strategist platform cut
+
+### IncreaseShareSupplyCap
+
+Allows the caller to increase the share supply cap
+
+Represents function `increaseShareSupplyCap(uint192 _newShareSupplyCap)`
+
+#### Fields
+- `new_cap`: (`string`) New share supply cap
+
+### SetSharePriceOracle
+
+Allows the caller to set the share price oracle contract
+
+Represents function `setSharePriceOracle(uint256 _registryId, ERC4626SharePriceOracle _sharePriceOracle)`
+
+#### Fields
+- `registry_id`: (`string`) The oracle registry ID
+- `share_price_oracle`: (`string`) The oracle contract address
+
+### CachePriceRouter
+
+Updates the cellar to use the latest price router in the registry.
+
+Represents function `cachePriceRouter(bool checkTotalAssets, uint16 allowableRange, address expectedPriceRouter)`
+
+#### Fields
+- `check_total_assets`: (`bool`) Whether to check the total assets of the cellar
+- `allowable_range`: (`uint32`) The allowable range of the cellar's total assets to deviate between old and new routers
+- `expected_price_router`: (`string`) The expected price router address
+```

--- a/strategists/cellar_functions.md
+++ b/strategists/cellar_functions.md
@@ -30,9 +30,6 @@ Note, some functions are destined to be gated by governance and are only tempora
 
 Additionally, the Cellar contract can be found [here](https://github.com/PeggyJV/cellar-contracts/blob/main/src/base/Cellar.sol). Each of the definitions below map to a function of the same name in the solidity code.
 
-Sure! Here is the complete Markdown v2 documentation in one code block:
-
-```markdown
 ### AddPosition
 
 Insert a trusted position to the list of positions used by the cellar at a given index.
@@ -235,4 +232,3 @@ Represents function `cachePriceRouter(bool checkTotalAssets, uint16 allowableRan
 - `check_total_assets`: (`bool`) Whether to check the total assets of the cellar
 - `allowable_range`: (`uint32`) The allowable range of the cellar's total assets to deviate between old and new routers
 - `expected_price_router`: (`string`) The expected price router address
-```

--- a/strategists/overview.md
+++ b/strategists/overview.md
@@ -11,6 +11,8 @@ Strategists are users or organizations responsible for submitting parameters for
 
 Strategists must also generate a Certificate Authority and use it to generate a self-signed certificate, which is the representation of a strategist's identity as a Publisher on the Sommelier chain required to create a trusted connection with the Steward API.
 
+Strategists are also responsible for writing their own logic for interacting with the Steward API in the language of their choice. The Steward API interfaces and gRPC client can be generated in many different languages.
+
 Requests to the Steward API use the type `ScheduleRequest`. This request contains contract call data and information used by the Sommelier chain to determine the destination of the contract and the timing of transaction execution. The response type `ScheduleResponse` contains information that can be used to query the Sommelier chain in order to confirm that a call, referred to on-chain as a Cork, was submitted and scheduled successfully. 
 
 ```protobuf

--- a/strategists/overview.md
+++ b/strategists/overview.md
@@ -1,0 +1,51 @@
+# Overview
+
+## Index
+- [Overview](#overview)
+- [Protobuf](./protobuf.md) 
+- [Requests](./requests.md)
+- [Cellar Functions](./cellar_functions.md) 
+- [Adaptor Reference](./adaptor_reference.md)
+
+Strategists are users or organizations responsible for submitting parameters for Cellar rebalances and other contract calls to Sommelier through the Steward API. To accomplish this they use the [Steward API](). The Steward API is defined by a protobuf package and can be used with a gRPC client. Strategists must generate proto bindings and a client from the Steward API protobuf files for their preferred language.
+
+Strategists must also generate a Certificate Authority and use it to generate a self-signed certificate, which is the representation of a strategist's identity as a Publisher on the Sommelier chain required to create a trusted connection with the Steward API.
+
+Requests to the Steward API use the type `ScheduleRequest`. This request contains contract call data and information used by the Sommelier chain to determine the destination of the contract and the timing of transaction execution. The response type `ScheduleResponse` contains information that can be used to query the Sommelier chain in order to confirm that a call, referred to on-chain as a Cork, was submitted and scheduled successfully. 
+
+```protobuf
+// Defined in steward/proto/steward/v4/steward.proto
+
+// Represents a scheduled function call to a particular Cellar
+message ScheduleRequest {
+    // The ID (currently simply an Ethereum address) of the target Cellar
+    string cellar_id = 1;
+    // The Sommelier block height at which to schedule the contract call
+    uint64 block_height = 2;
+    // The data from which the desired contract function will be encoded
+    oneof call_data {
+        AaveV2Stablecoin aave_v2_stablecoin = 3;
+        CellarV1 cellar_v1 = 4;
+        CellarV2 cellar_v2 = 5;
+        CellarV2_2 cellar_v2_2 = 6;
+        CellarV2_5 cellar_v2_5 = 7;
+    }
+    // The ID of the chain on which the target Cellar resides
+    uint64 chain_id = 8;
+    // The unix timestamp deadline for the contract call to be executed.
+    // Ignored for Ethereum Cellars.
+    uint64 deadline = 9;
+}
+
+message ScheduleResponse {
+    // The hex encoded ID of the scheduled cork
+    string id = 1;
+    // The ID of the chain on which the target Cellar resides
+    uint64 chain_id = 2;
+}
+```
+
+The request's `call_data` field contains the actual contract call arguments. Most strategists will be using the `CellarV2_5` call data type, which represents calls structured after the Cellar v2.5 architecture. 
+
+Strategists can execute a single function call or multiple function calls in the same transaction using the Multicall call type. The most important and complex function callable in Cellar v2.5 is `CallOnAdaptor`. It allows one or more adaptor function calls to be executed against a large selection of Sommelier adaptors defined in the Steward API.
+

--- a/strategists/protobuf.md
+++ b/strategists/protobuf.md
@@ -1,0 +1,11 @@
+# Protobuf
+
+If you are familiar with the use of Protocol Bufffers (protobuf) and gRPC, you can skip this page.
+
+> If you are interested in a deeper dive into Protocol Buffers, check out the [official documentation](https://protobuf.dev).
+
+In short, protobuf messages define types that can then be generated into any programming language. This allows for a common interface between different languages and platforms and saves time by automatically generating code for message serialization and deserialization and API client/server code.
+
+The Steward API is defined by a protobuf package and can be used with a gRPC client. Strategists must generate proto bindings and a client from the Steward API protobuf files for their preferred language using the [protoc compiler](https://grpc.io/docs/protoc-installation/) or [buf](https://buf.build).
+
+Please feel free to reach out to the Sommelier team for assistance with generating the necessary bindings in your language of choice if required.

--- a/strategists/requests.md
+++ b/strategists/requests.md
@@ -1,6 +1,6 @@
 # Requests
 
-As mentioned in the Overview, the main request type in the Steward API is `ScheduleRequest`, which is used to pass call data parameters to Steward which will then be built into the actualy contract call data.
+As mentioned in the Overview, Strategists must write their own code for interacting with Steward leveraging the protobuf definitions. The main request type in the Steward API is `ScheduleRequest`, which is used to pass call data parameters to Steward which will then be built into the actualy contract call data.
 The request proto defintion can be found [here]().
 
 ## Definition

--- a/strategists/requests.md
+++ b/strategists/requests.md
@@ -33,7 +33,7 @@ message ScheduleRequest {
 ## Fields
 
 - `block_height`: The Sommelier block height at which a bridge transaction will be created. This is when the bridging process begins, *not* when the EVM transaction is executed. There is an inherent delay between the time of this height and actualy transaction execution on the target contract.
-- `call_data`: The payload of contract call parameters.
+- `call_data`: The payload of contract call parameters. A detailed reference of the `CellarV2_5` type and its function definitions can be found in the [Cellar Functions](./cellar_functions.md) section.
 - `cellar_id`: The ID of the target Cellar, which is its EVM address. The address does not need to be checksummed (EIP-55) as the chain ID will provide target chain information.
 - `chain_id`: For non-Ethereum Cellars only. The EVM ID of the chain where the target Cellar resides. The default is 1, which is Ethereum Mainnet. Axelar provides a reference for other Mainnet chain IDs [here](https://docs.axelar.dev/resources/contract-addresses/mainnet).
 - `deadline`: For non-Ethereum Cellars only. This is the unix timestamp deadline for the contract call to be executed by Axelar. If Axelar fails to relay the transaction before the deadline it will not be executed. This field will be ignored for Ethereum Cellars.

--- a/strategists/requests.md
+++ b/strategists/requests.md
@@ -1,0 +1,39 @@
+# Requests
+
+As mentioned in the Overview, the main request type in the Steward API is `ScheduleRequest`, which is used to pass call data parameters to Steward which will then be built into the actualy contract call data.
+The request proto defintion can be found [here]().
+
+## Definition
+
+```protobuf
+// Defined in steward/proto/steward/v4/steward.proto
+
+// Represents a scheduled function call to a particular Cellar
+message ScheduleRequest {
+    // The ID (currently simply an Ethereum address) of the target Cellar
+    string cellar_id = 1;
+    // The Sommelier block height at which to schedule the contract call
+    uint64 block_height = 2;
+    // The data from which the desired contract function will be encoded
+    oneof call_data {
+        AaveV2Stablecoin aave_v2_stablecoin = 3;
+        CellarV1 cellar_v1 = 4;
+        CellarV2 cellar_v2 = 5;
+        CellarV2_2 cellar_v2_2 = 6;
+        CellarV2_5 cellar_v2_5 = 7;
+    }
+    // The ID of the chain on which the target Cellar resides
+    uint64 chain_id = 8;
+    // The unix timestamp deadline for the contract call to be executed.
+    // Ignored for Ethereum Cellars.
+    uint64 deadline = 9;
+}
+```
+
+## Fields
+
+- `block_height`: The Sommelier block height at which a bridge transaction will be created. This is when the bridging process begins, *not* when the EVM transaction is executed. There is an inherent delay between the time of this height and actualy transaction execution on the target contract.
+- `call_data`: The payload of contract call parameters.
+- `cellar_id`: The ID of the target Cellar, which is its EVM address. The address does not need to be checksummed (EIP-55) as the chain ID will provide target chain information.
+- `chain_id`: For non-Ethereum Cellars only. The EVM ID of the chain where the target Cellar resides. The default is 1, which is Ethereum Mainnet. Axelar provides a reference for other Mainnet chain IDs [here](https://docs.axelar.dev/resources/contract-addresses/mainnet).
+- `deadline`: For non-Ethereum Cellars only. This is the unix timestamp deadline for the contract call to be executed by Axelar. If Axelar fails to relay the transaction before the deadline it will not be executed. This field will be ignored for Ethereum Cellars.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `CallOnAdaptor` function for strategists to interact with various smart contracts like Aave, Uniswap, and Balancer.
  - Added detailed documentation for Cellar v2.5 contract functions and fields.
  - Provided an overview of the Steward API for strategists, including protobuf definitions for scheduling contract calls.

- **Updates**
  - Shifted approval process for strategists to governance, requiring on-chain proposals to become a Publisher.
  - Validators now need to create and submit their own self-signed certificates as a Subscriber in the x/pubsub module.
  - Modified submission timing and execution height for calls in the v7 upgrade.

- **Documentation**
  - Added new files detailing Protocol Buffers (protobuf) and gRPC, and their use in the Steward API.
  - Documented the `ScheduleRequest` message type for scheduling contract calls to Cellars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->